### PR TITLE
Add production info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,20 @@
+# tccd-code-club
+
 This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
 
 ## Getting Started
 
-First, run the development server:
+First, install dependencies:
+
+```bash
+npm install
+# or
+yarn install
+# or
+pnpm install
+```
+
+ to run the development server:
 
 ```bash
 npm run dev
@@ -11,6 +23,20 @@ yarn dev
 # or
 pnpm dev
 ```
+
+And to run the production server:
+
+```bash
+npm run build
+npm run start
+# or
+yarn build
+yarn start
+# or
+pnpm build
+pnpm start
+```
+
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
@@ -32,4 +58,3 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
-# tccd-code-club


### PR DESCRIPTION
This adds info on installing dependencies, and building and starting (for production, not dev) to README.md